### PR TITLE
fixed bug on filter and search

### DIFF
--- a/frontend/uevent/src/components/main_system/index.jsx
+++ b/frontend/uevent/src/components/main_system/index.jsx
@@ -60,7 +60,7 @@ const MainPage = () => {
             });
         } else {
             Promise.resolve(searchData(value)).then((res) => {
-                if (res?.data && res.data.length > 0) {
+                if (res?.data && res.data.length >= 0) {
                     const eventInfoResLocal = []
                     const eventInfoRes = res.data;
                     eventInfoRes.forEach((e) => {

--- a/frontend/uevent/src/components/main_system/index.jsx
+++ b/frontend/uevent/src/components/main_system/index.jsx
@@ -93,7 +93,7 @@ const MainPage = () => {
                             e.event_time,
                             e.average_rating,
                             e.event_image,
-                            e.filter_info
+                            [e.filter]
                         ));
                     });
                     setEventInfoArr(eventInfoResLocal);


### PR DESCRIPTION
1. filter bug
filter selection reflect cards shows all filters
Change: the api attribute is not filter_info, is filter

2. search
no reflection when search api return no events
Change: should manage data even though the return events are empty